### PR TITLE
Fix cmake error building videoio

### DIFF
--- a/Source/videoio/CMakeLists.txt
+++ b/Source/videoio/CMakeLists.txt
@@ -267,8 +267,8 @@ find_package(PkgConfig REQUIRED)
 pkg_check_modules(UDEV REQUIRED libudev)
 
 # Link against libudev
-ocv_target_link_libraries($module ${UDEV_LIBRARIES})
-ocv_target_include_directories($module PUBLIC ${UDEV_INCLUDE_DIRS})
+ocv_target_link_libraries(${the_module} ${UDEV_LIBRARIES})
+ocv_target_include_directories(${the_module} PUBLIC ${UDEV_INCLUDE_DIRS})
 
 # copy FFmpeg dll to the output folder
 if(WIN32 AND HAVE_FFMPEG_WRAPPER)


### PR DESCRIPTION
There was a typo in the CMakeLists.txt file of videoio, the variable `$module` should be `${the_module}`. It should close #11 